### PR TITLE
Bypass Parsing Messages into Data Classes

### DIFF
--- a/example_app.py
+++ b/example_app.py
@@ -2,10 +2,10 @@ import threading
 import signal
 import time
 import sys
-from threading import Timer,Thread,Event
+from threading import Event
 from intriniorealtime.client import IntrinioRealtimeClient
 from intriniorealtime.replay_client import IntrinioReplayClient
-import datetime
+from intriniorealtime.client import Quote
 
 trade_count = 0
 ask_count = 0
@@ -17,7 +17,7 @@ def on_quote(quote, backlog):
         global bid_count
         global backlog_count
         backlog_count = backlog
-        if 'type' in quote.__dict__:
+        if isinstance(quote, Quote) and 'type' in quote.__dict__:
             if quote.type == "ask": ask_count += 1
             else: bid_count += 1
 
@@ -44,12 +44,13 @@ class Summarize(threading.Thread):
 
 options = {
     'api_key': 'API_KEY_HERE',
-    'provider': 'REALTIME'  # 'REALTIME' or DELAYED_SIP or NASDAQ_BASIC
+    'provider': 'REALTIME',  # 'REALTIME' or DELAYED_SIP or NASDAQ_BASIC
     # ,'replay_date': datetime.date.today() - datetime.timedelta(days=1)  # needed for ReplayClient. The date to replay.
     # ,'with_simulated_delay': False  # needed for ReplayClient. This plays back the events at the same rate they happened in market.
     # ,'delete_file_when_done': True  # needed for ReplayClient
     # ,'write_to_csv': False  # needed for ReplayClient
     # ,'csv_file_path': 'data.csv'  # needed for ReplayClient
+    # 'bypass_parsing': True # if you want to handle parsing yourself, set this to True. Otherwise, leave it alone.
 }
 
 

--- a/intriniorealtime/client.py
+++ b/intriniorealtime/client.py
@@ -452,6 +452,7 @@ class QuoteHandler(threading.Thread):
         if message_type == 0:  # this is a trade
             if self.bypass_parsing and callable(self.client.on_trade):
                 self.client.on_trade(bytes[start_index:new_start_index-1], None)
+                return new_start_index
 
             item = self.parse_trade(bytes, start_index)
             if callable(self.client.on_trade):
@@ -462,6 +463,7 @@ class QuoteHandler(threading.Thread):
         else:  # message_type is ask or bid (quote)
             if self.bypass_parsing and callable(self.client.on_quote):
                 self.client.on_quote(bytes[start_index:new_start_index-1], None)
+                return new_start_index
             item = self.parse_quote(bytes, start_index)
             if callable(self.client.on_quote):
                 try:

--- a/intriniorealtime/client.py
+++ b/intriniorealtime/client.py
@@ -326,11 +326,11 @@ class QuoteReceiver(threading.Thread):
         self.client.ws.run_forever(skip_utf8_validation=True)  # skip_utf8_validation for more performance
         self.client.logger.debug("QuoteReceiver exiting")
 
-    def on_open(self):
+    def on_open(self, ws):
         self.client.logger.info("Websocket opened!")
         self.client.on_connect()
 
-    def on_close(self):
+    def on_close(self, ws, code, message):
         self.client.logger.info("Websocket closed!")
 
     def on_error(self, ws, error, *args):
@@ -451,7 +451,7 @@ class QuoteHandler(threading.Thread):
         item = None
         if message_type == 0:  # this is a trade
             if self.bypass_parsing and callable(self.client.on_trade):
-                self.client.on_trade(bytes[start_index:new_start_index-1])
+                self.client.on_trade(bytes[start_index:new_start_index-1], None)
 
             item = self.parse_trade(bytes, start_index)
             if callable(self.client.on_trade):
@@ -461,7 +461,7 @@ class QuoteHandler(threading.Thread):
                     self.client.logger.error(repr(e))
         else:  # message_type is ask or bid (quote)
             if self.bypass_parsing and callable(self.client.on_quote):
-                self.client.on_quote(bytes[start_index:new_start_index-1])
+                self.client.on_quote(bytes[start_index:new_start_index-1], None)
             item = self.parse_quote(bytes, start_index)
             if callable(self.client.on_quote):
                 try:


### PR DESCRIPTION
There are some processing inefficiencies regarding the `Trade` and `Quote` datatypes upstream. If you want to pick attributes from them and load them into your own data type, or `json.dump` (or `orjson.dump`) them, it is computationally expensive.  

In our pipeline, about 50% of the time to process events was being taken by randomly accessing the `Trade` and `Quote` objects. This takes an average of 0.34ms, but up to 3.11ms. With Nasdaq Basic having an average sustained throughput of 2,100 messages per second (firehose), with SIP even higher, it will limit max throughput and induce queueing. 

This PR introduces a `bypass_parsing` setting that returns the data fetched from the socket in bytes.


Improvements in my usecase: 

Our pipeline ingests TAQ events and pushes them to Kafka and Redis as JSON. Here's a flamegraph of before:

![image](https://github.com/intrinio/intrinio-realtime-python-sdk/assets/23005868/513a7a0c-0aad-408f-b37b-0044936dcf4d)

And here's a flamegraph of after (parsing bytes _directly_ into JSON, instead of Bytes -> `Trade` -> json dump) with `bypass_parsing` set `True` (latency reduced in this step from 0.34 to 0.001ms). Average processing time per message is 81 microseconds now, nice! 

![image](https://github.com/intrinio/intrinio-realtime-python-sdk/assets/23005868/2faee2e4-0ff3-44a8-bd5c-8c97ff8f8bfe)




