### PR TITLE
Allow multipart messages broken up by network

### DIFF
--- a/example_app_equities.py
+++ b/example_app_equities.py
@@ -82,7 +82,7 @@ client.connect()
 summarize_thread = Summarize(stop_event)
 summarize_thread.start()
 
-time.sleep(120)
+time.sleep(60 * 60 * 8)
 
 # sigint, or ctrl+c, during the thread wait will also perform the same below code.
 print("Stopping")

--- a/example_app_options.py
+++ b/example_app_options.py
@@ -147,6 +147,6 @@ intrinioRealtimeOptionsClient.join()
 # Use this to subscribe, dynamically, a list of specific option contracts or option chains.
 # intrinioRealtimeOptionsClient.join("GOOG__220408C02870000", "MSFT__220408C00315000", "AAPL__220414C00180000", "TSLA", "GE")
 
-time.sleep(60 * 60)
+time.sleep(60 * 60 * 8)
 # sigint, or ctrl+c, during the thread wait will also perform the same below code.
 on_kill_process(None, None)

--- a/intriniorealtime/equities_client.py
+++ b/intriniorealtime/equities_client.py
@@ -407,10 +407,12 @@ class EquitiesQuoteReceiver(threading.Thread):
         try:
             if DEBUGGING:  # This is here for performance reasons so we don't use slow reflection on every message.
                 if isinstance(partial_message, str):
-                    self.client.logger.debug(f"Received message (hex): {partial_message.encode('utf-8').hex()}")
+                    self.client.logger.debug(f"Received partial message (str): {partial_message.encode('utf-8').hex()}")
                 else:
                     if isinstance(partial_message, bytes):
-                        self.client.logger.debug(f"Received message (hex): {partial_message.hex()}")
+                        self.client.logger.debug(f"Received partial message (hex): {partial_message.hex()}")
+            #self.client.logger.debug(f"Received partial message (hex): {partial_message.hex()}")
+
             self.continuation_lock.acquire()
             try:
                 if is_last == 0:
@@ -437,7 +439,7 @@ class EquitiesQuoteReceiver(threading.Thread):
         try:
             if DEBUGGING:  # This is here for performance reasons so we don't use slow reflection on every message.
                 if isinstance(message, str):
-                    self.client.logger.debug(f"Received message (hex): {message.encode('utf-8').hex()}")
+                    self.client.logger.debug(f"Received message (str): {message.encode('utf-8').hex()}")
                 else:
                     if isinstance(message, bytes):
                         self.client.logger.debug(f"Received message (hex): {message.hex()}")

--- a/intriniorealtime/equities_client.py
+++ b/intriniorealtime/equities_client.py
@@ -414,9 +414,9 @@ class EquitiesQuoteReceiver(threading.Thread):
             self.continuation_lock.acquire()
             try:
                 if is_last == 0:
-                    self.continuation_queue.put_nowait(partial_message)
+                    self.continuation_queue.put(partial_message)
                 else:
-                    self.continuation_queue.put_nowait(partial_message)
+                    self.continuation_queue.put(partial_message)
                     full_message = self.stitch()
                     self.on_message(self.client.ws, full_message)
             finally:

--- a/intriniorealtime/options_client.py
+++ b/intriniorealtime/options_client.py
@@ -347,7 +347,7 @@ class _WebSocket(websocket.WebSocketApp):
     def __on_error(self, ws, error):
         _log.error("Websocket - Error - {0}".format(error))
 
-    def __on_data(self, ws, data, code, continueFlag):
+    def __on_data(self, ws, data, code, continueFlag): #continueFlag - If 0, the data continues
         if code == websocket.ABNF.OPCODE_BINARY:
             with _dataMsgLock:
                 global _dataMsgCount


### PR DESCRIPTION
Allow multi-part messages that were broken up by the network. This update stitches them back together. Prior to this, a broken up message may have its first chunk processed, but additional chunks in the sequence would not be processed because the format and indices would be off.